### PR TITLE
[Issue #59] Image ratio is preserved

### DIFF
--- a/src/components/annotation/AnnotationSurface.vue
+++ b/src/components/annotation/AnnotationSurface.vue
@@ -56,7 +56,7 @@ export default class AnnotationSurface extends Vue {
   public mounted(): void {
     window.addEventListener('resize', () => {
       const imageLoader = document.getElementsByClassName('image-loader')[0] as HTMLElement;
-      
+
       // We have to briefly display the image loader to get dimensions on client screen
       imageLoader.style.display = 'inline-block';
       this.state.updateRatio(imageLoader);
@@ -65,8 +65,10 @@ export default class AnnotationSurface extends Vue {
       imageLoader.style.display = 'none';
 
       const annotatorSurface = document.getElementById('annotator-surface') as HTMLElement;
-      const boxOffset: Point = {x: (annotatorSurface.offsetWidth / 2) - (this.imageHolderClientWidth / 2),
-                                y: (annotatorSurface.offsetHeight / 2) - (this.imageHolderClientHeight / 2)};
+      const boxOffset: Point = {
+        x: (annotatorSurface.offsetWidth / 2) - (this.imageHolderClientWidth / 2),
+        y: (annotatorSurface.offsetHeight / 2) - (this.imageHolderClientHeight / 2)
+      };
       this.state.updateBoxOffset(boxOffset);
     });
   }
@@ -79,7 +81,6 @@ export default class AnnotationSurface extends Vue {
    */
   private onMouseMove(event: MouseEvent): void {
     const elem = this.$el as HTMLElement;
-    
     const offset = {
       left: elem.offsetLeft + (elem.offsetWidth / 2) - (this.imageHolderClientWidth / 2),
       top: elem.offsetTop + (elem.offsetHeight / 2) - (this.imageHolderClientHeight / 2)

--- a/src/components/annotation/AnnotationSurface.vue
+++ b/src/components/annotation/AnnotationSurface.vue
@@ -27,7 +27,6 @@ import AnnotationStore from '@/store/store.annotation';
 
 import Box from '@/models/geometry/box';
 import Point from '@/models/geometry/point';
-import Size from '@/models/geometry/size';
 
 import { GridLoader } from '@saeris/vue-spinners';
 import BoundingBox from './BoundingBox.vue';
@@ -51,9 +50,24 @@ export default class AnnotationSurface extends Vue {
   /** Current drawed. */
   private readonly drawed: Box = { x: NaN, y: NaN, width: NaN, height: NaN };
 
+  private imageHolderClientWidth: number;
+  private imageHolderClientHeight: number;
+
   public mounted(): void {
     window.addEventListener('resize', () => {
-      this.state.updateRatio(this.$el as HTMLElement);
+      const imageLoader = document.getElementsByClassName('image-loader')[0] as HTMLElement;
+      
+      // We have to briefly display the image loader to get dimensions on client screen
+      imageLoader.style.display = 'inline-block';
+      this.state.updateRatio(imageLoader);
+      this.imageHolderClientWidth = imageLoader.clientWidth;
+      this.imageHolderClientHeight = imageLoader.clientHeight;
+      imageLoader.style.display = 'none';
+
+      const annotatorSurface = document.getElementById('annotator-surface') as HTMLElement;
+      const boxOffset: Point = {x: (annotatorSurface.offsetWidth / 2) - (this.imageHolderClientWidth / 2),
+                                y: (annotatorSurface.offsetHeight / 2) - (this.imageHolderClientHeight / 2)};
+      this.state.updateBoxOffset(boxOffset);
     });
   }
 
@@ -64,10 +78,11 @@ export default class AnnotationSurface extends Vue {
    * @param offset Cursor offset relative to this component origin.
    */
   private onMouseMove(event: MouseEvent): void {
-    const elem = this.$el;
+    const elem = this.$el as HTMLElement;
+    
     const offset = {
-      left: elem instanceof HTMLElement ? elem.offsetLeft : 0,
-      top: elem instanceof HTMLElement ? elem.offsetTop : 0
+      left: elem.offsetLeft + (elem.offsetWidth / 2) - (this.imageHolderClientWidth / 2),
+      top: elem.offsetTop + (elem.offsetHeight / 2) - (this.imageHolderClientHeight / 2)
     };
 
     const cursor = {
@@ -154,8 +169,8 @@ export default class AnnotationSurface extends Vue {
   border: 1px solid rgb(25, 25, 25);
   background-color: #003250;
   background-repeat: no-repeat;
-  background-position: 0 0;
-  background-size: 100% 100% !important;
+  background-position: center;
+  background-size: contain !important;
 }
 
 #loader-animation {

--- a/src/components/annotation/BoundingBox.vue
+++ b/src/components/annotation/BoundingBox.vue
@@ -119,11 +119,15 @@ export default class BoundingBox extends Vue {
   }
 
   get x(): number {
-    return Math.round(this.state.imageReverseRatio.width * this.box.x);
+    console.log('x= ' + this.box.x);
+    console.log('y= ' + this.box.y);
+    console.log('width= ' + this.box.width);
+    console.log('height= ' + this.box.height);
+    return Math.round(this.state.imageReverseRatio.width * this.box.x + this.state.boxOffset.x);
   }
 
   get y(): number {
-    return Math.round(this.state.imageReverseRatio.height * this.box.y);
+    return Math.round(this.state.imageReverseRatio.height * this.box.y + this.state.boxOffset.y);
   }
 
   get width(): number {

--- a/src/store/store.annotation.ts
+++ b/src/store/store.annotation.ts
@@ -60,6 +60,9 @@ export default class AnnotationStore extends VuexModule {
   /** Reverse applied image ratio. */
   public readonly imageReverseRatio: Size = { width: 1, height: 1 };
 
+  // Offset between background left and top sides and effective background left and top sides
+  public readonly boxOffset: Point = { x: NaN, y: NaN};
+
   /** List of user's drawn annotations. */
   public annotations: Annotation[] = [];
 
@@ -174,8 +177,8 @@ export default class AnnotationStore extends VuexModule {
         .catch((error) => {
           console.log(error);
         });
+      }
     }
-  }
 
   @Mutation
   public loadAnnotationClasses(): void {
@@ -333,6 +336,12 @@ export default class AnnotationStore extends VuexModule {
       this.relativeCursor.x = Math.round(offset.x);
       this.relativeCursor.y = Math.round(offset.y);
     }
+  }
+
+  @Mutation
+  public updateBoxOffset(offset: Point): void {
+    this.boxOffset.x = offset.x;
+    this.boxOffset.y = offset.y;
   }
 
   @Action


### PR DESCRIPTION
Issue #59 
Image ratio was not preserved for images in portrait mode for instance : 
![ratio KO](https://user-images.githubusercontent.com/27008404/107385097-e023bb00-6af2-11eb-91bf-6fda2bb1193c.png)

But now, image ratio is preserved and image will display like this :
![ratio OK](https://user-images.githubusercontent.com/27008404/107385195-f7fb3f00-6af2-11eb-84db-77b48365cccc.png)
