### PR TITLE
Fix calculation of bounding boxes when deleting

### DIFF
--- a/src/views/Annotate.vue
+++ b/src/views/Annotate.vue
@@ -151,7 +151,7 @@ export default class Annotate extends Vue {
 
   get currentAnnotationLabel() {
     return !isNaN(this.state.selectedAnnotationClass)
-      ? this.state.annotationClasses[this.state.selectedAnnotationClass].name
+      ? this.state.annotationClasses[this.state.selectedAnnotationClass - 1].name
       : '';
   }
 


### PR DESCRIPTION
When deleting bounding boxes, numbering was not updated if we had assigned a box with category with greatest id. Indeed, numbering of selected classes was broken in `currentAnnotationLabel()` because ids of classes are 1-indexed whereas arrays are 0-indexed.