### PR TITLE
Removed bottom shift when finishing drawing box

### DIFF
--- a/src/components/annotation/AnnotationSurface.vue
+++ b/src/components/annotation/AnnotationSurface.vue
@@ -53,6 +53,8 @@ export default class AnnotationSurface extends Vue {
   private imageHolderClientWidth: number;
   private imageHolderClientHeight: number;
 
+  private crossHeightShift: number;
+
   public mounted(): void {
     window.addEventListener('resize', () => {
       const imageLoader = document.getElementsByClassName('image-loader')[0] as HTMLElement;
@@ -70,6 +72,7 @@ export default class AnnotationSurface extends Vue {
         y: (annotatorSurface.offsetHeight / 2) - (this.imageHolderClientHeight / 2)
       };
       this.state.updateBoxOffset(boxOffset);
+      this.crossHeightShift = 24 * this.state.imageRatio.height;
     });
   }
 
@@ -142,7 +145,7 @@ export default class AnnotationSurface extends Vue {
         width: this.drawed.width,
         height: this.drawed.height,
         x: this.drawed.x,
-        y: this.drawed.y
+        y: this.drawed.y - this.crossHeightShift
       };
       const limitSize = this.state.minTrashSize;
       if (box.width > limitSize && box.height > limitSize) {

--- a/src/components/annotation/BoundingBox.vue
+++ b/src/components/annotation/BoundingBox.vue
@@ -18,7 +18,9 @@
     @click="onMouseClick"
   >
     <div>
-      <x-icon class="close-cross" @click="onClose" v-show="selected" />
+      <div class="close-cross-container" v-show="!isBeingDrawn">
+        <x-icon class="close-cross" @click="onClose" v-show="selected" />
+      </div>
       <div
         class="bounding-box-content"
         :style="{
@@ -98,6 +100,10 @@ export default class BoundingBox extends Vue {
     return this.state.annotations[id].box;
   }
 
+  get isBeingDrawn(): boolean {
+    return this.$props.id === 'raw';
+  }
+
   get labelled(): boolean {
     return this.state.annotations[this.$props.id] !== undefined;
   }
@@ -119,10 +125,6 @@ export default class BoundingBox extends Vue {
   }
 
   get x(): number {
-    console.log('x= ' + this.box.x);
-    console.log('y= ' + this.box.y);
-    console.log('width= ' + this.box.width);
-    console.log('height= ' + this.box.height);
     return Math.round(this.state.imageReverseRatio.width * this.box.x + this.state.boxOffset.x);
   }
 
@@ -224,6 +226,10 @@ export default class BoundingBox extends Vue {
   display: inline-block;
   justify-content: space-between;
   width: 200px;
+}
+
+.close-cross-container {
+  height: 24px;
 }
 
 .close-cross {


### PR DESCRIPTION
Issue #52 

When you finished drawing a box, it slightly shifted to bottom, which was undesired. This shift is now removed.

Some useless console.log have been removed also.