### PR TITLE
Tag list dropdown width match largest element

### DIFF
--- a/src/components/annotation/BoundingBox.vue
+++ b/src/components/annotation/BoundingBox.vue
@@ -174,7 +174,12 @@ export default class BoundingBox extends Vue {
   }
 }
 </script>
-
+<style>
+.multiselect__content-wrapper {
+  overflow-y: scroll;
+  width: unset;
+}
+</style>
 <style scoped>
 .bounding-box {
   position: absolute;


### PR DESCRIPTION
Issue #66 
The width of the tag list dropdown will now match the width of largest element. (we won(t have to horizontal-scroll anymore)