### PR TITLE
:sparkles: Add checkbox for contains trash

### DIFF
--- a/src/components/annotate/AnnotationSurface.vue
+++ b/src/components/annotate/AnnotationSurface.vue
@@ -86,10 +86,8 @@ export default class AnnotationSurface extends Vue {
             ) as HTMLElement;
             const annotatorWidth = annotatorSurface.offsetWidth;
             const annotatorHeight = annotatorSurface.offsetHeight;
-            const {
-                actualImageWidth,
-                actualImageHeight
-            } = this.estimateActualImageSize(annotatorWidth, annotatorHeight);
+            const { actualImageWidth, actualImageHeight } =
+                this.estimateActualImageSize(annotatorWidth, annotatorHeight);
             this.$store.commit("updateRatio", {
                 actualImageWidth,
                 actualImageHeight
@@ -154,7 +152,8 @@ export default class AnnotationSurface extends Vue {
         if (
             this.$el === event.target &&
             !this.drawing &&
-            isNaN(this.$store.state.selectedAnnotationIndex)
+            isNaN(this.$store.state.selectedAnnotationIndex) &&
+            this.$store.state.contextSelections.containsTrash
         ) {
             event.preventDefault();
             this.drawed.width = 0;

--- a/src/components/annotate/ContextSelectionPanel.vue
+++ b/src/components/annotate/ContextSelectionPanel.vue
@@ -45,13 +45,12 @@
         <div class="context-group">
             <b-form-group>
                 <b-form-checkbox
-                    id="containsTrash"
-                    v-model="containsTrash"
-                    name="containsTrash"
+                    id="containsNoTrash"
+                    v-model="containsNoTrash"
+                    name="containsNoTrash"
                     value="true"
-                    unchecked-value="false"
                 >
-                    This image contains trash
+                    This image does not contain trash or is inappropriate
                 </b-form-checkbox>
             </b-form-group>
         </div>
@@ -70,34 +69,25 @@ export default class ContextSelectionPanel extends Vue {
             environmentSelection: null,
             viewPointSelection: null,
             qualitySelection: null,
-            containsTrash: true,
+            containsNoTrash: false,
 
             environmentOptions: environmentOptions,
             viewPointOptions: viewPointOptions,
             qualityOptions: qualityOptions
         };
     }
-    get isComplete() {
-        return (
-            !!this.$data.environmentSelection &&
-            !!this.$data.viewPointSelection &&
-            !!this.$data.qualitySelection
-        );
-    }
 
     @Watch("environmentSelection")
     @Watch("viewPointSelection")
     @Watch("qualitySelection")
-    @Watch("containsTrash")
+    @Watch("containsNoTrash")
     private onSelectionChange() {
-        if (this.isComplete) {
-            this.$store.commit("setContextSelections", {
-                quality: this.$data.qualitySelection,
-                viewPoint: this.$data.viewPointSelection,
-                environment: this.$data.environmentSelection,
-                containsTrash: this.$data.containsTrash
-            });
-        }
+        this.$store.commit("setContextSelections", {
+            quality: this.$data.qualitySelection,
+            viewPoint: this.$data.viewPointSelection,
+            environment: this.$data.environmentSelection,
+            containsTrash: this.$data.containsNoTrash === false
+        });
     }
     public resetContextSelections() {
         this.$data.environmentSelection = null;

--- a/src/components/annotate/ContextSelectionPanel.vue
+++ b/src/components/annotate/ContextSelectionPanel.vue
@@ -10,6 +10,7 @@
                     buttons
                     button-variant="dark"
                     size="sm"
+                    :disabled="!!containsNoTrash"
                 />
             </b-form-group>
         </div>
@@ -24,6 +25,7 @@
                     buttons
                     button-variant="dark"
                     size="sm"
+                    :disabled="!!containsNoTrash"
                 />
             </b-form-group>
         </div>
@@ -38,6 +40,7 @@
                     name="quality-buttons"
                     button-variant="dark"
                     size="sm"
+                    :disabled="!!containsNoTrash"
                 />
             </b-form-group>
         </div>

--- a/src/components/annotate/ContextSelectionPanel.vue
+++ b/src/components/annotate/ContextSelectionPanel.vue
@@ -96,6 +96,7 @@ export default class ContextSelectionPanel extends Vue {
         this.$data.environmentSelection = null;
         this.$data.qualitySelection = null;
         this.$data.viewPointSelection = null;
+        this.$data.containsNoTrash = false;
         this.$store.commit("resetContextSelections");
     }
 }

--- a/src/components/annotate/ContextSelectionPanel.vue
+++ b/src/components/annotate/ContextSelectionPanel.vue
@@ -41,6 +41,20 @@
                 />
             </b-form-group>
         </div>
+
+        <div class="context-group">
+            <b-form-group>
+                <b-form-checkbox
+                    id="containsTrash"
+                    v-model="containsTrash"
+                    name="containsTrash"
+                    value="true"
+                    unchecked-value="false"
+                >
+                    This image contains trash
+                </b-form-checkbox>
+            </b-form-group>
+        </div>
     </div>
 </template>
 <script lang="ts">
@@ -56,6 +70,7 @@ export default class ContextSelectionPanel extends Vue {
             environmentSelection: null,
             viewPointSelection: null,
             qualitySelection: null,
+            containsTrash: true,
 
             environmentOptions: environmentOptions,
             viewPointOptions: viewPointOptions,
@@ -73,12 +88,14 @@ export default class ContextSelectionPanel extends Vue {
     @Watch("environmentSelection")
     @Watch("viewPointSelection")
     @Watch("qualitySelection")
+    @Watch("containsTrash")
     private onSelectionChange() {
         if (this.isComplete) {
             this.$store.commit("setContextSelections", {
                 quality: this.$data.qualitySelection,
                 viewPoint: this.$data.viewPointSelection,
-                environment: this.$data.environmentSelection
+                environment: this.$data.environmentSelection,
+                containsTrash: this.$data.containsTrash
             });
         }
     }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -110,6 +110,9 @@ const mutations = {
     },
     setContextSelections(state: State, contextSelections: ContextSelections) {
         state.contextSelections = contextSelections;
+        if (!contextSelections.containsTrash) {
+            state.annotations = [];
+        }
     },
     resetContextSelections(state: State) {
         state.contextSelections = undefined;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -35,6 +35,7 @@ type ContextSelections = {
     quality: QualityValue | null;
     viewPoint: ViewPoint | null;
     environment: EnvironmentValue | null;
+    containsTrash: boolean;
 };
 export type State = {
     axiosRequestConfig?: AxiosRequestConfig;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -325,6 +325,7 @@ const store = new Vuex.Store({
                 filename: "",
                 view: this.state.contextSelections?.viewPoint,
                 imgQuality: this.state.contextSelections?.quality,
+                containsTrash: this.state.contextSelections?.containsTrash,
                 context: this.state.contextSelections?.environment,
                 url: this.state.image.url,
                 bbox: []

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -86,7 +86,13 @@ export const initialState: State = {
 
     annotations: [],
     annotationLabels: [],
-    minTrashSize: 20 // Limit size for trash (in pixels) */
+    minTrashSize: 20, // Limit size for trash (in pixels) */
+    contextSelections: {
+        quality: null,
+        viewPoint: null,
+        environment: null,
+        containsTrash: true
+    }
 };
 
 const mutations = {

--- a/src/views/Annotate.vue
+++ b/src/views/Annotate.vue
@@ -120,11 +120,11 @@ export default class Annotate extends Vue {
 
     private onClickValidateButton() {
         const contextSelectionPanel = this.$store.state.contextSelections;
-        console.log(contextSelectionPanel);
         if (
-            contextSelectionPanel.environment === null ||
-            contextSelectionPanel.viewPoint === null ||
-            contextSelectionPanel.quality === null
+            (contextSelectionPanel.environment === null ||
+                contextSelectionPanel.viewPoint === null ||
+                contextSelectionPanel.quality === null) &&
+            contextSelectionPanel.containsTrash === true
         ) {
             this.$modal.show("dialog", {
                 title: "Invalid information",

--- a/src/views/Annotate.vue
+++ b/src/views/Annotate.vue
@@ -26,7 +26,7 @@
                 <!-- TODO : disable the button if !state.contextSelections  -->
                 <b-button
                     variant="primary"
-                    :disabled="false"
+                    :disabled="!this.canSubmitAnnotation()"
                     @click="onClickValidateButton"
                     >Validate
                     {{ this.$store.getters.numberOfAnnotations }}
@@ -116,6 +116,13 @@ export default class Annotate extends Vue {
                 { title: "Cancel" }
             ]
         });
+    }
+
+    private canSubmitAnnotation() {
+        return (
+            this.$store.state.annotations.length >= 1 ||
+            this.$store.state.contextSelections.containsTrash === false
+        );
     }
 
     private onClickValidateButton() {


### PR DESCRIPTION
Ajout d'une case pour signaler que la photo contient (ou non) des déchets. Elle est cochée par défaut.

Côté API, je renvois une propriété `containsTrash` dans le payload avec une string qui est "true" ou "false". @Vincent-Guiberteau Si tu veux que je change la propriété du payload, fais moi signe !

![Screenshot 2022-02-25 at 12-41-49 Plastic Origin - DLP](https://user-images.githubusercontent.com/3785695/155709449-07cd3dee-6ee8-4093-9656-12d17a466836.png)

